### PR TITLE
exit process with exitCode from the command

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -2,4 +2,5 @@
 
 const shell = require('shelljs');
 require('./index')();
-shell.exec(process.argv.slice(2).join(' '));
+const result = shell.exec(process.argv.slice(2).join(' '));
+process.exit(result.code)


### PR DESCRIPTION
right now it always exits with zero, thats causing CI to ignore errors from tests for example.