### PR TITLE
Fix parsed order in README (switched .env.local and .env.NODE_ENV)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,6 @@ add `.local` files to `.gitignore`
 The first value set (or those already defined in the environment) take precedence:
 
 - `.env` - The Original®
-- `.env.development`, `.env.test`, `.env.production` - Environment-specific settings.
 - `.env.local` - Local overrides. This file is loaded for all environments _except_ `test`.
+- `.env.development`, `.env.test`, `.env.production` - Environment-specific settings.
 - `.env.development.local`, `.env.test.local`, `.env.production.local` - Local overrides of environment-specific settings.


### PR DESCRIPTION
See corresponding code:

https://github.com/formatlos/dotenv-load/blob/4c1297bc0c79d9bc6260ade918dbbef13a1974a1/index.js#L15-L21